### PR TITLE
Centralize Marten configuration

### DIFF
--- a/src/AssociationRegistry.Admin.AddressSync/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AssociationRegistry.Admin.AddressSync/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Marten.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
+using AssociationRegistry.Hosts.Marten;
 using Npgsql;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
@@ -77,8 +78,8 @@ public static class ServiceCollectionExtensions
                                                serviceProvider =>
                                                {
                                                    var opts = new StoreOptions();
-                                                   opts.Connection(postgreSqlOptions.GetConnectionString());
-                                                   opts.Serializer(CreateMartenSerializer());
+                                                   opts.Connection(CommonMartenConfigurator.BuildConnectionString(postgreSqlOptions));
+                                                   opts.Serializer(CommonMartenConfigurator.CreateSerializer());
                                                    opts.Events.StreamIdentity = StreamIdentity.AsString;
 
                                                    opts.Events.MetadataConfig.EnableAll();
@@ -108,19 +109,7 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    private static JsonNetSerializer CreateMartenSerializer()
-    {
-        var jsonNetSerializer = new JsonNetSerializer();
-
-        jsonNetSerializer.Customize(
-            s =>
-            {
-                s.DateParseHandling = DateParseHandling.None;
-            });
-
-        return jsonNetSerializer;
-    }
-
+    
     public static string CollectorUrl
         => Environment.GetEnvironmentVariable("COLLECTOR_URL") ?? "http://localhost:4317";
 

--- a/src/AssociationRegistry.Hosts/Marten/CommonMartenConfigurator.cs
+++ b/src/AssociationRegistry.Hosts/Marten/CommonMartenConfigurator.cs
@@ -1,0 +1,23 @@
+namespace AssociationRegistry.Hosts.Marten;
+
+using AssociationRegistry.Hosts.Configuration.ConfigurationBindings;
+using Marten.Services;
+using Newtonsoft.Json;
+
+public static class CommonMartenConfigurator
+{
+    public static string BuildConnectionString(PostgreSqlOptionsSection options)
+        => options.GetConnectionString();
+
+    public static JsonNetSerializer CreateSerializer(params JsonConverter[] converters)
+    {
+        var serializer = new JsonNetSerializer();
+        serializer.Customize(settings =>
+        {
+            settings.DateParseHandling = DateParseHandling.None;
+            foreach (var converter in converters)
+                settings.Converters.Add(converter);
+        });
+        return serializer;
+    }
+}

--- a/src/AssociationRegistry.Hosts/paket.references
+++ b/src/AssociationRegistry.Hosts/paket.references
@@ -1,5 +1,6 @@
 NEST
 Npgsql
+Marten
 Serilog
 Microsoft.Extensions.Configuration
 Microsoft.Extensions.Configuration.Binder

--- a/src/AssociationRegistry.KboMutations.SyncLambda/Services/ServiceFactory.cs
+++ b/src/AssociationRegistry.KboMutations.SyncLambda/Services/ServiceFactory.cs
@@ -18,6 +18,7 @@ using Marten.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using AssociationRegistry.Hosts.Marten;
 using Npgsql;
 using Telemetry;
 using Weasel.Core;
@@ -151,7 +152,9 @@ public class ServiceFactory
         opts.Schema.For<MagdaCallReference>().Identity(x => x.Reference);
         opts.Connection(connectionString);
         opts.Events.StreamIdentity = StreamIdentity.AsString;
-        opts.Serializer(CreateCustomMartenSerializer());
+        opts.Serializer(CommonMartenConfigurator.CreateSerializer(
+            new NullableDateOnlyJsonConvertor(WellknownFormats.DateOnly),
+            new DateOnlyJsonConvertor(WellknownFormats.DateOnly)));
         opts.Events.MetadataConfig.EnableAll();
         opts.AutoCreateSchemaObjects = AutoCreate.None;
 
@@ -165,19 +168,6 @@ public class ServiceFactory
         return opts;
     }
 
-    private static JsonNetSerializer CreateCustomMartenSerializer()
-    {
-        var jsonNetSerializer = new JsonNetSerializer();
-
-        jsonNetSerializer.Customize(s =>
-        {
-            s.DateParseHandling = DateParseHandling.None;
-            s.Converters.Add(new NullableDateOnlyJsonConvertor(WellknownFormats.DateOnly));
-            s.Converters.Add(new DateOnlyJsonConvertor(WellknownFormats.DateOnly));
-        });
-
-        return jsonNetSerializer;
-    }
 
     private static VerenigingsRepository CreateRepository(DocumentStore store, ILoggerFactory loggerFactory)
     {

--- a/src/AssociationRegistry.PowerBi.ExportHost/Infrastructure/Extensions/ServiceCollectionMartenExtensions.cs
+++ b/src/AssociationRegistry.PowerBi.ExportHost/Infrastructure/Extensions/ServiceCollectionMartenExtensions.cs
@@ -6,6 +6,7 @@ using Marten;
 using Marten.Events;
 using Marten.Services;
 using Newtonsoft.Json;
+using AssociationRegistry.Hosts.Marten;
 using Weasel.Core;
 
 public static class ServiceCollectionMartenExtensions
@@ -13,8 +14,8 @@ public static class ServiceCollectionMartenExtensions
     public static StoreOptions GetStoreOptions(PostgreSqlOptionsSection postgreSqlOptions)
     {
         var opts = new StoreOptions();
-        opts.Connection(postgreSqlOptions.GetConnectionString());
-        opts.Serializer(CreateMartenSerializer());
+        opts.Connection(CommonMartenConfigurator.BuildConnectionString(postgreSqlOptions));
+        opts.Serializer(CommonMartenConfigurator.CreateSerializer());
         opts.Events.StreamIdentity = StreamIdentity.AsString;
 
         opts.Events.MetadataConfig.EnableAll();
@@ -29,16 +30,4 @@ public static class ServiceCollectionMartenExtensions
         return opts;
     }
 
-    private static JsonNetSerializer CreateMartenSerializer()
-    {
-        var jsonNetSerializer = new JsonNetSerializer();
-
-        jsonNetSerializer.Customize(
-            s =>
-            {
-                s.DateParseHandling = DateParseHandling.None;
-            });
-
-        return jsonNetSerializer;
-    }
 }

--- a/src/AssociationRegistry.Public.Api/Infrastructure/Extensions/MartenExtensions.cs
+++ b/src/AssociationRegistry.Public.Api/Infrastructure/Extensions/MartenExtensions.cs
@@ -2,6 +2,7 @@
 
 using Constants;
 using Json;
+using AssociationRegistry.Hosts.Marten;
 using Marten;
 using Marten.Events;
 using Marten.Services;
@@ -18,7 +19,7 @@ public static class MartenExtensions
     {
         services.AddMarten(_ =>
         {
-            var connectionString1 = GetPostgresConnectionString(postgreSqlOptions);
+            var connectionString1 = CommonMartenConfigurator.BuildConnectionString(postgreSqlOptions);
 
             var opts = new StoreOptions();
 
@@ -34,7 +35,9 @@ public static class MartenExtensions
 
             opts.Events.MetadataConfig.EnableAll();
 
-            opts.Serializer(CreateCustomMartenSerializer());
+            opts.Serializer(CommonMartenConfigurator.CreateSerializer(
+                new NullableDateOnlyJsonConvertor(WellknownFormats.DateOnly),
+                new DateOnlyJsonConvertor(WellknownFormats.DateOnly)));
 
             return opts;
         }).UseLightweightSessions();
@@ -42,23 +45,5 @@ public static class MartenExtensions
         return services;
     }
 
-    private static string GetPostgresConnectionString(PostgreSqlOptionsSection postgreSqlOptions)
-        => $"host={postgreSqlOptions.Host};" +
-           $"database={postgreSqlOptions.Database};" +
-           $"password={postgreSqlOptions.Password};" +
-           $"username={postgreSqlOptions.Username}";
 
-    public static JsonNetSerializer CreateCustomMartenSerializer()
-    {
-        var jsonNetSerializer = new JsonNetSerializer();
-
-        jsonNetSerializer.Customize(
-            s =>
-            {
-                s.Converters.Add(new NullableDateOnlyJsonConvertor(WellknownFormats.DateOnly));
-                s.Converters.Add(new DateOnlyJsonConvertor(WellknownFormats.DateOnly));
-            });
-
-        return jsonNetSerializer;
-    }
 }


### PR DESCRIPTION
## Summary
- add `CommonMartenConfigurator` under `AssociationRegistry.Hosts`
- reuse connection string and serializer builder across projects

## Testing
- `./build.sh Test_Solution` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e2cc05448326817f7382dea72ce8